### PR TITLE
Fix Python 3 support

### DIFF
--- a/notebooks/view-everything.ipynb
+++ b/notebooks/view-everything.ipynb
@@ -15,12 +15,26 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 1,
    "metadata": {
     "collapsed": false,
     "scrolled": true
    },
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<b>.[0:2]</b>no content"
+      ],
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 1,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "### mandatory init\n",
     "%matplotlib inline\n",
@@ -31,7 +45,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "metadata": {
     "collapsed": false
    },
@@ -61,7 +75,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython2",
-   "version": "2.7.6"
+   "version": "2.7.9"
   }
  },
  "nbformat": 4,

--- a/radiopadre/__init__.py
+++ b/radiopadre/__init__.py
@@ -206,7 +206,7 @@ def latest (*args):
     args = dict([(type(arg),arg) for arg in args])
     dl = lsd(pattern=args.get(str),sort='txn')
     if not dl:
-        raise IOError,"no subdirectories here"
+        raise IOError("no subdirectories here")
     return dl[-args.get(int, -1)].lsr()
 
 
@@ -249,7 +249,7 @@ class DirList(list):
         #
         if _scan:
             if not os.path.exists(rootfolder):
-                raise IOError,"directory %s does not exist"%rootfolder
+                raise IOError("directory %s does not exist") % rootfolder
             for dir_, dirnames, files in os.walk(rootfolder):
                 # exclude subdirectories
                 if not recursive and dir_ != rootfolder:
@@ -271,7 +271,7 @@ class DirList(list):
 
     def latest (self, num=1):
         if not self:
-            raise IOError,"no subdirectories in %s"%self._root
+            raise IOError("no subdirectories in %s" % self._root)
         return self.sort("t")[-num]
 
     def sort(self, opt="xnt"):

--- a/radiopadre/file.py
+++ b/radiopadre/file.py
@@ -86,7 +86,7 @@ class FileBase(object):
         return self.show() or self.path
 
     def show(self, **kw):
-        print self.path
+        print(self.path)
 
 
 def data_file(path, root=""):

--- a/radiopadre/fitsfile.py
+++ b/radiopadre/fitsfile.py
@@ -26,7 +26,7 @@ class FITSFile(radiopadre.file.FileBase):
         sizes = [str(hdr["NAXIS%d" % i]) for i in range(1, hdr["NAXIS"] + 1)]
         axes = [hdr.get("CTYPE%d" % i, str(i))
                 for i in range(1, hdr["NAXIS"] + 1)]
-        print self.path, "x".join(sizes), ",".join(axes)
+        print(self.path, "x".join(sizes), ",".join(axes))
 
     @staticmethod
     def _show_summary(fits_files, title=None, showpath=False):
@@ -45,7 +45,7 @@ class FITSFile(radiopadre.file.FileBase):
                     [str(hdr.get("NAXIS%d" % i)) for i in range(1, naxis + 1)])
                 axes = ",".join(
                     [hdr.get("CTYPE%d" % i, "?").split("-", 1)[0] for i in range(1, naxis + 1)])
-                delt = [abs(hdr.get("CDELT%d" % i, 0)) for i in 1, 2]
+                delt = [abs(hdr.get("CDELT%d" % i, 0)) for i in (1, 2)]
                 resolution = []
                 if all(delt):
                     if delt[0] == delt[1]:
@@ -149,7 +149,7 @@ class FITSFile(radiopadre.file.FileBase):
         for ax in remaining_axes:
             labels = self.FITSAxisLabels.get(axis_type[ax], None)
             rval, rpix, delt, unit = [hdr.get("C%s%d" % (kw, ax + 1), 1)
-                                      for kw in "RVAL", "RPIX", "DELT", "UNIT"]
+                                      for kw in ("RVAL", "RPIX", "DELT", "UNIT")]
             if labels:
                 axis_labels[ax] = ["%s %s" %
                                    (axis_type[ax], labels[int(rval - 1 + delt *

--- a/radiopadre/imagefile.py
+++ b/radiopadre/imagefile.py
@@ -5,7 +5,7 @@ import IPython.display
 from IPython.display import HTML, display
 
 import radiopadre
-import radiopadre.file
+from radiopadre.file import FileBase, compute_thumb_geometry
 
 
 def _make_thumbnail(image, width):
@@ -22,11 +22,11 @@ def _make_thumbnail(image, width):
         if not os.access(thumbdir, os.W_OK) or os.path.exists(thumb) and not os.access(thumb, os.W_OK):
             return None
         if os.system("convert -thumbnail %d %s %s" % (width, image, thumb)):
-            raise RuntimeError, "thumbnail convert failed, maybe imagemagick is not installed?"
+            raise RuntimeError("thumbnail convert failed, maybe imagemagick is not installed?")
     return thumb
 
 
-class ImageFile(radiopadre.file.FileBase):
+class ImageFile(FileBase):
 
     @staticmethod
     def _show_thumbs(images, width=None, ncol=None, maxwidth=None, mincol=None,
@@ -35,9 +35,8 @@ class ImageFile(radiopadre.file.FileBase):
 
         if not images:
             return None
-        nrow, ncol, width = radiopadre.file.compute_thumb_geometry(len(images), ncol,
-                                                              mincol, maxcol,
-                                                              width, maxwidth)
+        nrow, ncol, width = compute_thumb_geometry(len(images), ncol, mincol,
+                                                   maxcol, width, maxwidth)
         npix = int(radiopadre.DPI * width)
 
         # make list of basename, filename  tuples


### PR DESCRIPTION
It is not hard to write code that supports python 2.7 and 3

What I fixed here is changed raise notation. use `raise Exception("why")`

Also use `print()` function, not print statement.

Last thingy is the sorting of lists changed a bit, didn't fix that yet.

https://docs.python.org/3/howto/sorting.html#the-old-way-using-the-cmp-parameter